### PR TITLE
Ghidra should not suppress exceptions from scripts

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/FilteredMemoryState.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/FilteredMemoryState.java
@@ -34,12 +34,8 @@ class FilteredMemoryState extends MemoryState {
 		int readLen = super.getChunk(res, spc, off, size, stopOnUnintialized);
 		if (filterEnabled && filter != null) {
 			filterEnabled = false;
-			try {
-				filter.filterRead(spc, off, readLen, res);
-			}
-			finally {
-				filterEnabled = true;
-			}
+			filter.filterRead(spc, off, readLen, res);
+			filterEnabled = true;
 		}
 		return readLen;
 	}
@@ -49,12 +45,8 @@ class FilteredMemoryState extends MemoryState {
 		super.setChunk(res, spc, off, size);
 		if (filterEnabled && filter != null) {
 			filterEnabled = false;
-			try {
-				filter.filterWrite(spc, off, size, res);
-			}
-			finally {
-				filterEnabled = true;
-			}
+			filter.filterWrite(spc, off, size, res);
+			filterEnabled = true;
 		}
 	}
 


### PR DESCRIPTION
Blanket-suppressing exceptions deprives writers of Ghidra Scripts the ability to handle or even see and know about exceptions in their MemoryAccessFilter's