### PR TITLE
Memory filters should get write event before write

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/FilteredMemoryState.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/FilteredMemoryState.java
@@ -46,7 +46,6 @@ class FilteredMemoryState extends MemoryState {
 
 	@Override
 	public void setChunk(byte[] res, AddressSpace spc, long off, int size) {
-		super.setChunk(res, spc, off, size);
 		if (filterEnabled && filter != null) {
 			filterEnabled = false;
 			try {
@@ -56,6 +55,7 @@ class FilteredMemoryState extends MemoryState {
 				filterEnabled = true;
 			}
 		}
+		super.setChunk(res, spc, off, size);
 	}
 
 	MemoryAccessFilter setFilter(MemoryAccessFilter filter) {


### PR DESCRIPTION
Getting the write event before the write happens is important so that the old value, which will be overwritten, can be retrieved if needed. Whether the filter happens before or after the write does not make a difference to the emulator.